### PR TITLE
chore(docker): use alpine base image

### DIFF
--- a/packages/dendron-cli/Dockerfile
+++ b/packages/dendron-cli/Dockerfile
@@ -1,3 +1,4 @@
-FROM node:16
-RUN npm install -g @sxltd/dendron-cli
+FROM node:16-alpine
+RUN npm install -g @sxltd/dendron-cli --omit=dev
+RUN npm cache clean --force
 ENTRYPOINT ["npx", "@sxltd/dendron-cli"]


### PR DESCRIPTION
use alpine docker base image for smaller image size (1.25gb -> 500mb)