### PR TITLE
chore: clean up individual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "resolutions": {
     "trim": "0.0.3",
     "d3-color": "3.1.0",
-    "typescript": "5.9.3",
     "@types/lodash": "4.14.187",
     "@types/babel__traverse": "7.0.6",
     "undici": "5.29.0"

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -20,16 +20,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
-    "format": "echo nop",
-    "lint": "echo stub",
-    "prepublishOnly": "yarn build",
+    "clean": "rm -rf lib coverage",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.build.json ",
-    "coverage": "echo no-op",
-    "watch": "yarn compile --watch",
+    "build": "tsc -p tsconfig.build.json",
+    "watch": "yarn build --watch",
     "start:local:old": "cross-env PORT=3005 LOG_LEVEL=info npx ts-node ./src/start.ts",
     "start:local": "cross-env PORT=3005 LOG_LEVEL=info nodemon --watch 'src/**/*.ts' lib/start.js",
     "local:dev:custom": "env AWS_PROFILE=dendron-dev LOCAL=true PORT=3005 LOG_LEVEL=info nodemon --watch 'server/**/*.ts' dist/server/index.js | pino-pretty | tee /tmp/out.txt",
@@ -44,8 +38,8 @@
     "@types/morgan": "^1.9.1",
     "@types/node": "13.11.0",
     "nodemon": "^2.0.4",
-    "rimraf": "^2.6.2",
-    "ts-node": "^8.10.2"
+    "ts-node": "^8.10.2",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -22,15 +22,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
-    "format": "echo nop",
-    "lint": "echo stub",
-    "prepublishOnly": "yarn build",
+    "clean": "rm -rf lib coverage",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.build.json ",
-    "watch": "yarn compile --watch"
+    "build": "tsc -p tsconfig.build.json ",
+    "watch": "yarn build --watch"
   },
   "dependencies": {
     "@swc/helpers": "^0.3.2",
@@ -70,9 +65,9 @@
     "@types/title": "^3.4.1",
     "@types/unist": "^2.0.3",
     "coveralls": "^3.0.2",
-    "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0"
+    "tslint-config-prettier": "^1.15.0",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -6,8 +6,7 @@
   "license": "Apache 2.0",
   "scripts": {
     "watch": "echo nop",
-    "build": "node scripts/buildStyles.js && gulp less js",
-    "buildCI": "yarn build"
+    "build": "node scripts/buildStyles.js && gulp less js"
   },
   "gitHead": "4ba39ff9fcec3bd1f0ba4fbd663cb3b49449609b",
   "devDependencies": {

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -23,14 +23,9 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf lib coverage",
-    "format": "echo nop",
-    "lint": "echo stub",
-    "prepublishOnly": "yarn build",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.build.json ",
-    "watch": "yarn compile --watch"
+    "build": "tsc -p tsconfig.build.json ",
+    "watch": "yarn build --watch"
   },
   "dependencies": {
     "@aws-amplify/core": "^4.0.2",
@@ -47,7 +42,8 @@
     "@types/lodash": "^4.14.161",
     "@types/node": "^14.11.2",
     "@types/react": "^17.0.5",
-    "@types/redux-logger": "^3.0.9"
+    "@types/redux-logger": "^3.0.9",
+    "typescript": "^5.9.3"
   },
   "nohoist": [
     "**/common-all",

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -23,16 +23,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
-    "format": "echo nop",
-    "lint": "echo stub",
-    "prepublishOnly": "yarn build",
+    "clean": "rm -rf lib coverage",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.build.json ",
-    "coverage": "echo nop",
-    "watch": "yarn compile --watch"
+    "build": "tsc -p tsconfig.build.json ",
+    "watch": "yarn build --watch"
   },
   "dependencies": {
     "@sxltd/common-all": "workspace:*",
@@ -67,10 +61,10 @@
     "@types/spark-md5": "^3.0.2",
     "@types/tmp": "^0.2.0",
     "coveralls": "^3.0.2",
-    "rimraf": "^2.6.2",
     "ts-node": "^8.10.2",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0"
+    "tslint-config-prettier": "^1.15.0",
+    "typescript": "^5.9.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/common-test-utils/package.json
+++ b/packages/common-test-utils/package.json
@@ -21,23 +21,17 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
-    "format": "echo nop",
-    "lint": "echo stub",
-    "prepublishOnly": "yarn build",
+    "clean": "rm -rf lib coverage",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.json ",
-    "coverage": "echo 0 ",
-    "watch": "yarn compile --watch"
+    "build": "tsc -p tsconfig.json",
+    "watch": "yarn build --watch"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.1",
     "@types/lodash": "^4.14.161",
     "@types/node": "13.11.0",
-    "rimraf": "^2.6.2",
-    "ts-node": "^8.10.2"
+    "ts-node": "^8.10.2",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/dendron-viz/package.json
+++ b/packages/dendron-viz/package.json
@@ -22,11 +22,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
-    "prepublishOnly": "yarn build",
+    "clean": "rm -rf lib coverage",
     "prebuild": "yarn clean",
     "build": "yarn copyNonTSFiles && yarn compile",
-    "buildCI": "yarn copyNonTSFiles && yarn compile",
     "copyNonTSFiles": "node ./ensureDir && node copy",
     "compile": "tsc -p tsconfig.build.json",
     "watch": "yarn copyNonTSFiles && yarn compile --watch"
@@ -43,7 +41,7 @@
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.2",
-    "rimraf": "^2.6.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -23,14 +23,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage && rimraf src/drivers/generated-prisma-client",
-    "format": "echo nop",
-    "lint": "echo stub",
+    "clean": "rm -rf lib coverage src/drivers/generated-prisma-client",
     "buildPrismaClient": "yarn prisma generate && node copyPrismaClient.js",
     "prepublishOnly": "yarn build",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
     "build": "yarn compile && yarn buildPrismaClient",
-    "buildCI": "yarn compile && yarn buildPrismaClient",
     "compile": "tsc -p tsconfig.build.json ",
     "watch": "yarn compile --watch"
   },
@@ -100,10 +97,10 @@
     "coveralls": "^3.0.2",
     "cross-env": "^7.0.2",
     "prisma": "^4.1.1",
-    "rimraf": "^2.6.2",
     "ts-node": "^8.10.2",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0"
+    "tslint-config-prettier": "^1.15.0",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -22,8 +22,6 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf lib coverage",
-    "format": "echo nop",
-    "lint": "echo stub",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
     "build": "tsc -p tsconfig.build.json",
     "coverage": "jest --coverage",

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -22,15 +22,13 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
+    "clean": "rm -rf lib coverage",
     "format": "echo nop",
     "lint": "echo stub",
     "prepublishOnly": "yarn build",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.build.json ",
-    "watch": "yarn compile --watch",
+    "build": "tsc -p tsconfig.build.json ",
+    "watch": "yarn build --watch",
     "test:unit:debug": "NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand"
   },
   "devDependencies": {
@@ -41,8 +39,8 @@
     "@types/lodash": "^4.14.161",
     "@types/node": "13.11.0",
     "@types/through2": "^2.0.36",
-    "rimraf": "^2.6.2",
-    "ts-node": "^8.10.2"
+    "ts-node": "^8.10.2",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -22,13 +22,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "clean": "rimraf lib && rimraf coverage",
-    "prepublishOnly": "yarn build",
+    "clean": "rm -rf lib coverage",
     "prebuild": "yarn clean",
-    "build": "yarn compile",
-    "buildCI": "yarn compile",
-    "compile": "tsc -p tsconfig.build.json",
-    "watch": "yarn compile --watch"
+    "build": "tsc -p tsconfig.build.json",
+    "watch": "yarn build --watch"
   },
   "dependencies": {
     "@sxltd/common-all": "workspace:*",
@@ -65,7 +62,7 @@
   "devDependencies": {
     "@types/mdast": "^3.0.10",
     "@types/unist": "^2.0.6",
-    "rimraf": "^2.6.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7785,7 +7785,7 @@ __metadata:
     remark-toc: ^7.0.0
     remark-variables: ^1.4.9
     remark-wiki-link: ^0.0.4
-    rimraf: ^2.6.2
+    typescript: ^5.9.3
     unified: ^9.2.2
     unified-engine: ^8.0.0
     unist-util-select: ^3.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -7482,7 +7482,7 @@ __metadata:
     micromatch: ^4.0.4
     react: ^17.0.2
     react-dom: ^17.0.2
-    rimraf: ^2.6.2
+    typescript: ^5.9.3
     yargs: ^17.4.1
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -7738,9 +7738,9 @@ __metadata:
     klaw: ^3.0.0
     limiter: ^2.1.0
     lodash: ^4.17.20
-    rimraf: ^2.6.2
     through2: ^4.0.2
     ts-node: ^8.10.2
+    typescript: ^5.9.3
     vscode-uri: ^2.1.2
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -7236,6 +7236,7 @@ __metadata:
     react-dom: ^17.0.2
     react-redux: ^7.2.3
     redux-logger: ^3.0.6
+    typescript: ^5.9.3
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7154,8 +7154,8 @@ __metadata:
     morgan: ^1.10.0
     nodemon: ^2.0.4
     querystring: ^0.2.1
-    rimraf: ^2.6.2
     ts-node: ^8.10.2
+    typescript: ^5.9.3
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -38968,7 +38968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
+"typescript@npm:5.9, typescript@npm:5.9.3, typescript@npm:^5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -38978,13 +38978,73 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>":
+"typescript@npm:^3.7.3, typescript@npm:^3.9.10, typescript@npm:^3.9.5, typescript@npm:^3.9.7":
+  version: 3.9.10
+  resolution: "typescript@npm:3.9.10"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 46c842e2cd4797b88b66ef06c9c41dd21da48b95787072ccf39d5f2aa3124361bc4c966aa1c7f709fae0509614d76751455b5231b12dbb72eb97a31369e1ff92
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.1.2, typescript@npm:^4.2.3, typescript@npm:^4.4.3":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  languageName: node
+  linkType: hard
+
+"typescript@npm:~4.3.4":
+  version: 4.3.5
+  resolution: "typescript@npm:4.3.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@5.9#~builtin<compat/typescript>, typescript@patch:typescript@5.9.3#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.3#~builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=29ae49"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^3.7.3#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.10#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.7#~builtin<compat/typescript>":
+  version: 3.9.10
+  resolution: "typescript@patch:typescript@npm%3A3.9.10#~builtin<compat/typescript>::version=3.9.10&hash=3bd3d3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: dc7141ab555b23a8650a6787f98845fc11692063d02b75ff49433091b3af2fe3d773650dea18389d7c21f47d620fb3b110ea363dab4ab039417a6ccbbaf96fc2
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.1.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.2.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.3.4#~builtin<compat/typescript>":
+  version: 4.3.5
+  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=dba6d9"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 365df18cf979c971ef9543b2acaa8694377a803f98e1804c41d0ede0b09d7046cb0cd98f2eaf3884b0fe923c01a60af1f653841bd8805c9715d5479c09a4ebe4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7192,12 +7192,12 @@ __metadata:
     neverthrow: ^5.0.0
     normalize-path: ^3.0.0
     qs: ^6.10.1
-    rimraf: ^2.6.2
     semver: ^7.3.2
     spark-md5: ^3.0.2
     title: ^3.4.4
     tslint: ^5.11.0
     tslint-config-prettier: ^1.15.0
+    typescript: ^5.9.3
     vscode-uri: ^3.0.3
     zod: 3.19.1
     zod-validation-error: ^0.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -7268,7 +7268,6 @@ __metadata:
     lodash: ^4.17.15
     pino: ^6.3.2
     pino-pretty: ^4.3.0
-    rimraf: ^2.6.2
     simple-git: ^3.3.0
     spark-md5: ^3.0.2
     textextensions: ^5.15.0
@@ -7276,6 +7275,7 @@ __metadata:
     ts-node: ^8.10.2
     tslint: ^5.11.0
     tslint-config-prettier: ^1.15.0
+    typescript: ^5.9.3
     vscode-uri: ^2.1.2
     yaml-unist-parser: ^1.3.1
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -7545,7 +7545,6 @@ __metadata:
     remark-toc: ^7.0.0
     remark-variables: ^1.4.9
     remark-wiki-link: ^0.0.4
-    rimraf: ^2.6.2
     spark-md5: ^3.0.1
     sqlite3: ^5.1.2
     stream: ^0.0.2
@@ -7553,6 +7552,7 @@ __metadata:
     ts-node: ^8.10.2
     tslint: ^5.11.0
     tslint-config-prettier: ^1.15.0
+    typescript: ^5.9.3
     unified: ^9.1.0
     unified-engine: ^8.0.0
     unist-util-select: ^3.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -7295,9 +7295,9 @@ __metadata:
     fs-extra: ^9.0.1
     jest: ^28.1.0
     lodash: ^4.17.20
-    rimraf: ^2.6.2
     sinon: ^9.2.1
     ts-node: ^8.10.2
+    typescript: ^5.9.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- workspaces now build individually with `yarn workspace <name> build`
- removed forced resolution of typescript version
- removed buildCI scripts and rimraf dependency in package.json files