### PR TITLE
fix(docker): add git to dockerfile

### DIFF
--- a/packages/dendron-cli/Dockerfile
+++ b/packages/dendron-cli/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:18-alpine
+RUN apk add --no-cache git
 RUN npm install -g @sxltd/dendron-cli --omit=dev
 RUN npm cache clean --force
 ENTRYPOINT ["npx", "@sxltd/dendron-cli"]


### PR DESCRIPTION
The switch to alpine meant that `git` was no longer in the built image; `dendron-cli` clones the nextjs templates as part of the `publish` commands, which requires `git`.