### PR TITLE
fix(cli): allow `publish` commands to work with `--wsRoot` set to relative paths

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,5 @@ seeds
 
 generated-api-*
 .backup
+
+.next

--- a/package.json
+++ b/package.json
@@ -47,14 +47,11 @@
     "build:plugin": "yarn workspace dendron build:plugin",
     "clean": "yarn workspaces foreach -ptv --exclude @sxltd/nextjs-template --exclude root run clean",
     "test": "LOG_LEVEL=error jest",
-    "test:cli": "LOG_LEVEL=error jest --selectProjects non-plugin-tests --forceExit",
     "test:plugin": "xvfb-run yarn workspace @sxltd/plugin-core test",
     "test:cli:update-snapshots": "yarn test:cli -u",
-    "format": "lerna exec --parallel -- yarn format",
     "format:pkg": "prettier --write",
     "lint": "eslint . --ext ts,tsx",
-    "dendron": "node packages/dendron-cli/lib/bin/dendron-cli.js",
-    "lerna:typecheck": "lerna exec --parallel --ignore @sxltd/common-assets --ignore @sxltd/dendron-plugin-views -- tsc -p tsconfig.build.json --noEmit"
+    "dendron": "node -r ./jest.setup.js packages/dendron-cli/lib/bin/dendron-cli.js"
   },
   "dependencies": {
     "@babel/helper-string-parser": "^7.22.5",

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -32,7 +32,7 @@
     "format": "echo nop",
     "lint": "echo stub",
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && chmod +x ./lib/bin/dendron-cli.js",
     "watch": "yarn build --watch"
   },
   "dependencies": {

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/dendron-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "dendron-cli",
   "license": "Apache 2.0",
   "repository": {

--- a/packages/dendron-cli/src/commands/publishCLICommand.ts
+++ b/packages/dendron-cli/src/commands/publishCLICommand.ts
@@ -83,9 +83,6 @@ type ExportCmdOpts = DevCmdOpts & { target?: PublishTarget; yes?: boolean };
 export { CommandOpts as PublishCLICommandOpts };
 export { CommandCLIOpts as PublishCLICommandCLIOpts };
 
-const getNextRoot = (wsRoot: string) => {
-  return path.join(wsRoot, ".next");
-};
 
 const isBuildOverrideKey = (key: string): key is keyof BuildOverrides => {
   const allowedKeys = [
@@ -248,7 +245,7 @@ export class PublishCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     const cli = new ExportPodCLICommand();
     // create config string
     const podConfig: NextjsExportConfig = {
-      dest: dest || getNextRoot(wsRoot),
+      dest: dest || NextjsExportPodUtils.getNextRoot(wsRoot),
     };
     const resp = await cli.enrichArgs({
       podId: NextjsExportPod.id,

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/pods-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "pods-core",
   "license": "Apache 2.0",
   "repository": {

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -43,6 +43,7 @@ import { URI } from "vscode-uri";
 import { ExportPod, ExportPodConfig, ExportPodPlantOpts } from "../basev3";
 import { PodUtils } from "../utils";
 
+
 const ID = "dendron.nextjs";
 
 const TEMPLATE_REMOTE = "origin";
@@ -133,7 +134,13 @@ export class NextjsExportPodUtils {
   };
 
   static getNextRoot = (wsRoot: string) => {
-    return path.join(wsRoot, ".next");
+
+    if (path.isAbsolute(wsRoot)){
+      return path.join(wsRoot, ".next");
+    }
+    else{
+      return path.join(path.resolve(wsRoot), ".next");
+    }
   };
 
   static async nextPathExists(opts: { nextPath: string }) {

--- a/test-workspace/.gitignore
+++ b/test-workspace/.gitignore
@@ -8,3 +8,4 @@ pods/*
 .history
 .backup
 *.svg
+.next


### PR DESCRIPTION
closes #24 

In short, path handling with `simple-git` and relative paths in the `--wsRoot` flag did not play nicely together.
The simplest solution is to convert all paths to absolute paths.

# Pull Request Checklist

- [x] packages are bumped as appropriate
- [x] all tests pass

note: these will stop being manual checks once CI is in place to handle them.

<!-- paste test results here if tests have changed
test results:
```

```

-->