### PR TITLE
fix(views): import all scss files during webpack

### DIFF
--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sxltd/common-assets",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "index.js",
   "license": "Apache 2.0",
   "scripts": {

--- a/packages/common-assets/styles/scss/_portal.scss
+++ b/packages/common-assets/styles/scss/_portal.scss
@@ -1,6 +1,9 @@
 @use "sass:math";
 @use "sass:color";
-@use "./main" as *;
+//@use "./main" as *;
+
+$text-color: #111 !default;
+$base-line-height: 1 !default;
 
 // Clear normal iframe styles
 iframe {

--- a/packages/common-assets/styles/scss/main-plugin.scss
+++ b/packages/common-assets/styles/scss/main-plugin.scss
@@ -1,4 +1,5 @@
-
+@use "./base";
+@use "./main";
 
 
 // base.scss

--- a/packages/common-assets/styles/scss/main.scss
+++ b/packages/common-assets/styles/scss/main.scss
@@ -12,13 +12,13 @@
 // @import "variables.scss";
 @use "./typography" as *;
 @use "./utilities/utilities" as *;
+@use "./portal" as *;
 
 // Portal Start
-$base-line-height: 1 !default;
+
 $spacing-unit: 30px !default;
-$text-color: #111 !default;
+
 // Portal end
-@use "portal.scss" as *;
 
 // for task links, the decorations around the links
 .task-before {

--- a/packages/dendron-plugin-views/package.json
+++ b/packages/dendron-plugin-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/dendron-plugin-views",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "workspaces": {
     "nohoist": [

--- a/packages/dendron-plugin-views/src/components/DendronNotePreview.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronNotePreview.tsx
@@ -15,6 +15,7 @@ import React from "react";
 import { useCurrentTheme, useMermaid, useRenderedNoteBody } from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage } from "../utils/vscode";
+import "../styles/scss/main-plugin.scss";
 
 function isHTMLAnchorElement(element: Element): element is HTMLAnchorElement {
   return element.nodeName === "A";

--- a/packages/dendron-plugin-views/webpack.config.js
+++ b/packages/dendron-plugin-views/webpack.config.js
@@ -82,9 +82,7 @@ module.exports = {
               {
                 loader: 'css-loader',
                 options: {
-                  modules: {
-                    namedExport: false 
-                  }
+                  modules: false,
                 }
               },
                'sass-loader']

--- a/packages/dendron-plugin-views/webpack.config.js
+++ b/packages/dendron-plugin-views/webpack.config.js
@@ -67,7 +67,9 @@ module.exports = {
               {
                 loader: 'css-loader',
                 options: {
-                  modules: false,
+                  modules: {
+                    namedExport: false
+                  }
                 }
               },
               'sass-loader'

--- a/packages/dendron-plugin-views/webpack.config.js
+++ b/packages/dendron-plugin-views/webpack.config.js
@@ -67,9 +67,7 @@ module.exports = {
               {
                 loader: 'css-loader',
                 options: {
-                  modules: {
-                    namedExport: false
-                  }
+                  modules: false,
                 }
               },
               'sass-loader'
@@ -93,9 +91,7 @@ module.exports = {
               {
                 loader: 'css-loader',
                 options: {
-                  modules: {
-                    namedExport: false
-                  }
+                  modules: false,
                 }
               },
             ]

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -4,7 +4,7 @@
   "displayName": "dendron",
   "description": "Dendron is a hierarchical note taking tool that grows as you do.",
   "publisher": "dendron",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "sponsor": {
     "url": "https://accounts.dendron.so/account/subscribe"
   },

--- a/packages/plugin-extension/package.json
+++ b/packages/plugin-extension/package.json
@@ -4,7 +4,7 @@
     "displayName": "dendron",
     "description": "Dendron is a hierarchical note taking tool that grows as you do.",
     "publisher": "dendron",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "sponsor": {
         "url": "https://accounts.dendron.so/account/subscribe"
     },


### PR DESCRIPTION
closes #33 

In short, the changes in `use` vs `import` caused some scss styles (e.g. `_portal.scss`) to no longer be imported.
This change restores that behavior; tables and note refs display with the proper CSS again.

<img width="587" height="270" alt="image" src="https://github.com/user-attachments/assets/a6817229-98de-4e7b-a7e8-64f5c222fcd6" />


# Pull Request Checklist

- [x] packages are bumped as appropriate
- [x] all tests pass

note: these will stop being manual checks once CI is in place to handle them.

<!-- paste test results here if tests have changed
test results:
```

```

-->