### PR TITLE
fix(publishing): checkout branch for nextjs template repository

### DIFF
--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/dendron-cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "dendron-cli",
   "license": "Apache 2.0",
   "repository": {

--- a/packages/dendron-cli/src/commands/publishCLICommand.ts
+++ b/packages/dendron-cli/src/commands/publishCLICommand.ts
@@ -332,12 +332,15 @@ export class PublishCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       spinner,
     });
 
+    let shouldInit = true;
+
     if (nextPathExists) {
       try {
         await this._updateNextTemplate({
           nextPath,
           spinner,
         });
+        shouldInit = false;
       } catch (err) {
         SpinnerUtils.renderAndContinue({
           spinner,
@@ -347,9 +350,10 @@ export class PublishCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           nextPath,
           spinner,
         });
-        await this._initialize({ nextPath, spinner });
       }
-    } else {
+    }
+
+    if (shouldInit) {
       await this._initialize({ nextPath, spinner });
     }
 

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/pods-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "pods-core",
   "license": "Apache 2.0",
   "repository": {

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -186,7 +186,7 @@ export class NextjsExportPodUtils {
 
     let status = await git.status();
     if (status.current !== TEMPLATE_BRANCH) {
-      await git.checkout(TEMPLATE_REMOTE_URL);
+      await git.checkout(TEMPLATE_BRANCH, ['-f']);
       status = await git.status();
     }
     const remoteBranch = `${TEMPLATE_REMOTE}/${TEMPLATE_BRANCH}`;

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -165,6 +165,7 @@ export class NextjsExportPodUtils {
     await fs.ensureDir(nextPath);
     const git = simpleGit({ baseDir: nextPath });
     await git.clone(TEMPLATE_REMOTE_URL, nextPath);
+    await git.checkout(TEMPLATE_BRANCH);
 
     return { error: null };
   }


### PR DESCRIPTION
This change cleans up some bugs in the `dendron publish` flow:
- Cloning a nextjs template into an un-initialized workspace now respects branch (`TEMPLATE_BRANCH`)
- Updating an existing nextjs template now correctly uses branch name (previous behavior caused a fresh clone instead, due to `TEMPLATE_REMOTE_URL` being used instead of `TEMPLATE_BRANCH`)
- checking out to a different branch now works when there are changes in the current branch (e.g. `yarn.lock` or `package.json` from installing)

# Pull Request Checklist

- [x] packages are bumped as appropriate
- [x] all tests pass

note: these will stop being manual checks once CI is in place to handle them.

<!-- paste test results here if tests have changed
test results:
```

```

-->