### PR TITLE
chore(publish): use `@sxltd/nextjs-template` during nextjs export

### DIFF
--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/pods-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "pods-core",
   "license": "Apache 2.0",
   "repository": {

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -47,7 +47,7 @@ import { PodUtils } from "../utils";
 const ID = "dendron.nextjs";
 
 const TEMPLATE_REMOTE = "origin";
-const TEMPLATE_REMOTE_URL = "https://github.com/dendronhq/nextjs-template.git";
+const TEMPLATE_REMOTE_URL = "https://github.com/sxltd/nextjs-template.git";
 const TEMPLATE_BRANCH = "main";
 
 const $$ = execa.command;

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -48,7 +48,7 @@ const ID = "dendron.nextjs";
 
 const TEMPLATE_REMOTE = "origin";
 const TEMPLATE_REMOTE_URL = "https://github.com/sxltd/nextjs-template.git";
-const TEMPLATE_BRANCH = "main";
+const TEMPLATE_BRANCH = "v0.1.0";
 
 const $$ = execa.command;
 

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -48,7 +48,7 @@ const ID = "dendron.nextjs";
 
 const TEMPLATE_REMOTE = "origin";
 const TEMPLATE_REMOTE_URL = "https://github.com/sxltd/nextjs-template.git";
-const TEMPLATE_BRANCH = "v0.1.0";
+const TEMPLATE_BRANCH = "main";
 
 const $$ = execa.command;
 


### PR DESCRIPTION
Small change, necessary for future improvements to nextjs export flow.

# Pull Request Checklist

- [x] packages are bumped as appropriate
- [x] all tests pass

note: these will stop being manual checks once CI is in place to handle them.

<!-- paste test results here if tests have changed
test results:
```

```

-->