### PR TITLE
enhance(publish): support git refs in nextjs export

### DIFF
--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sxltd/pods-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "pods-core",
   "license": "Apache 2.0",
   "repository": {

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -48,7 +48,7 @@ const ID = "dendron.nextjs";
 
 const TEMPLATE_REMOTE = "origin";
 const TEMPLATE_REMOTE_URL = "https://github.com/sxltd/nextjs-template.git";
-const TEMPLATE_BRANCH = "v0.1.0";
+const TEMPLATE_REF = "v0.1.0";
 
 const $$ = execa.command;
 
@@ -165,7 +165,7 @@ export class NextjsExportPodUtils {
     await fs.ensureDir(nextPath);
     const git = simpleGit({ baseDir: nextPath });
     await git.clone(TEMPLATE_REMOTE_URL, nextPath);
-    await git.checkout(TEMPLATE_BRANCH);
+    await git.checkout(TEMPLATE_REF);
 
     return { error: null };
   }
@@ -194,11 +194,11 @@ export class NextjsExportPodUtils {
 
     //it doesn't matter what ref we're on, get latest and checkout anyways
     await git.fetch();
-    await git.checkout(TEMPLATE_BRANCH, ['-f']);
+    await git.checkout(TEMPLATE_REF, ['-f']);
 
     let currentRef = await NextjsExportPodUtils.getCurrentRef(git);
-    if (currentRef !== TEMPLATE_BRANCH) {
-      throw new Error(`${currentRef} is not expected remote ref (${TEMPLATE_BRANCH})`);
+    if (currentRef !== TEMPLATE_REF) {
+      throw new Error(`${currentRef} is not expected remote ref (${TEMPLATE_REF})`);
     }
   }
 


### PR DESCRIPTION
Refs are now supported for use in nextjs export.
The default ref has been changed from `main` to `v0.1.0` in @sxltd/nextjs-template. At the time of writing, these point to the same commit, but `main` will diverge in the near future, which is the motivation for this change.

# Pull Request Checklist

- [x] packages are bumped as appropriate
- [x] all tests pass

note: these will stop being manual checks once CI is in place to handle them.

<!-- paste test results here if tests have changed
test results:
```

```

-->